### PR TITLE
Fix internal NumberFormat instance locale

### DIFF
--- a/src/plural-rules.js
+++ b/src/plural-rules.js
@@ -68,7 +68,8 @@ export default class PluralRules {
     this._locale = resolveLocale(locales)
     this._type = getType(opt.type)
     if (typeof Intl === 'object' && Intl.NumberFormat) {
-      this._nf = new Intl.NumberFormat(this._locale, opt)
+      // make-plural expects latin digits with . decimal separator
+      this._nf = new Intl.NumberFormat('en', opt)
     } else {
       const {
         minimumIntegerDigits: minID,

--- a/src/plural-rules.test.js
+++ b/src/plural-rules.test.js
@@ -106,6 +106,11 @@ describe('Intl.PluralRules polyfill', () => {
       expect(p.select('3.0')).toBe('few')
       expect(p.select(11)).toBe('other')
     })
+    test('should work for Arabic', () => {
+      const p = new PluralRules('ar-SA')
+      expect(p.select(0)).toBe('zero')
+      expect(p.select(1)).toBe('one')
+    })
     test('should work with minimumFractionDigits: 1', () => {
       const p = new PluralRules('en', { minimumFractionDigits: 1 })
       expect(p.select(1)).toBe('other')

--- a/src/plural-rules.test.js
+++ b/src/plural-rules.test.js
@@ -139,5 +139,13 @@ describe('Intl.PluralRules polyfill', () => {
       expect(p.select(2)).toBe('other')
       expect(p.select('-2.0')).toBe('other')
     })
+    test('should work with "," as decimal separator', () => {
+      const p0 = new PluralRules('cs', { minimumFractionDigits: 0 })
+      const p1 = new PluralRules('cs', { minimumFractionDigits: 1 })
+      expect(p0.select(1)).toBe('one')
+      expect(p1.select(1)).toBe('many')
+      expect(p0.select(10)).toBe('other')
+      expect(p1.select(10)).toBe('many')
+    })
   })
 })


### PR DESCRIPTION
Right now this test is failing bc `intl-pluralrules` uses `Intl.NumberFormat` to format the number, which in Arabic is not number (but Arabic characters rather). This results in all `PluralRules` for `ar` becoming `other`.

Fixes #4