### PR TITLE
convert number to absolute value before selecting

### DIFF
--- a/src/plural-rules.js
+++ b/src/plural-rules.js
@@ -129,7 +129,7 @@ export default class PluralRules {
   select(number) {
     if (typeof number !== 'number') number = Number(number)
     if (!isFinite(number)) return 'other'
-    const fmt = this._format(number)
+    const fmt = this._format(Math.abs(number))
     return pluralRules[this._locale](fmt, this._type === 'ordinal')
   }
 }

--- a/src/plural-rules.test.js
+++ b/src/plural-rules.test.js
@@ -96,6 +96,7 @@ describe('Intl.PluralRules polyfill', () => {
       const p = new PluralRules('en', { type: 'cardinal' })
       expect(p.select(1)).toBe('one')
       expect(p.select('1.0')).toBe('one')
+      expect(p.select(-1)).toBe('one')
       expect(p.select(2)).toBe('other')
       expect(p.select('-2.0')).toBe('other')
     })


### PR DESCRIPTION
Right now on native `Intl.PluralRules` platforms, negative numbers produce the same result as positive number. The [CLDR chart](https://www.unicode.org/cldr/charts/34/supplemental/language_plural_rules.html) also doesn't mention negative numbers at all