### PR TITLE
include factory.js instead of .mjs on react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
   "browser": {
     "./factory.js": "./factory.mjs"
   },
+  "react-native": {
+    "./factory": "./factory.js"
+  },
   "jest": {
     "collectCoverage": true,
     "moduleFileExtensions": [


### PR DESCRIPTION
Currently react-native (more specifically metro) doesn't handle mjs. See: https://github.com/facebook/metro/issues/535