### PR TITLE
Add support for selectRange() from Intl.Numberformat v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ PluralRules class with locale support limited to only what you actually use.
 [make-plural]: https://www.npmjs.com/package/make-plural
 
 Thanks to tree-shaking, this example that only supports English and French
-minifies & gzips to 1448 bytes. Do note that this size difference is only
+minifies & gzips to 1472 bytes. Do note that this size difference is only
 apparent with minified production builds.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # intl-pluralrules
 
-A spec-compliant implementation & polyfill for [Intl.PluralRules]. Particularly
-useful if you need proper support for [`minimumFractionDigits`], which are only
-supported in Chrome 77 & later.
+A spec-compliant implementation & polyfill for [Intl.PluralRules],
+including the `selectRange(start, end)` method introduced in [Intl.NumberFormat v3].
+Also useful if you need proper support for [`minimumFractionDigits`],
+which are only supported in Chrome 77 & later.
+
+For a polyfill without `selectRange()`, please use `intl-pluralrules@1`.
 
 [intl.pluralrules]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules
+[intl.numberformat v3]: https://github.com/tc39/proposal-intl-numberformat-v3/
 [`minimumfractiondigits`]: https://bugs.chromium.org/p/v8/issues/detail?id=8866
 
 ## Installation
@@ -22,9 +26,10 @@ available in your environment:
 import 'intl-pluralrules'
 ```
 
-If `Intl.PluralRules` already exists and supports
-[multiple locales](https://nodejs.org/api/intl.html), the polyfill will not be
-loaded. Full support for `minimumFractionDigits` is not checked.
+If `Intl.PluralRules` already exists,
+includes a `selectRange()` method,
+and supports [multiple locales](https://nodejs.org/api/intl.html),
+the polyfill will not be loaded.
 
 ## Ponyfill
 
@@ -37,6 +42,8 @@ import PluralRules from 'intl-pluralrules/plural-rules'
 
 new PluralRules('en').select(1) // 'one'
 new PluralRules('en', { minimumSignificantDigits: 3 }).select(1) // 'other'
+new PluralRules('en').selectRange(0, 1) // 'other'
+new PluralRules('fr').selectRange(0, 1) // 'one'
 ```
 
 ## Factory
@@ -50,13 +57,14 @@ PluralRules class with locale support limited to only what you actually use.
 [make-plural]: https://www.npmjs.com/package/make-plural
 
 Thanks to tree-shaking, this example that only supports English and French
-minifies & gzips to 1619 bytes. Do note that this size difference is only
+minifies & gzips to 1448 bytes. Do note that this size difference is only
 apparent with minified production builds.
 
 ```js
 import getPluralRules from 'intl-pluralrules/factory'
 import { en, fr } from 'make-plural/plurals'
 import { en as enCat, fr as frCat } from 'make-plural/pluralCategories'
+import { en as enRange, fr as frRange } from 'make-plural/ranges'
 
 const sel = { en, fr }
 const getSelector = lc => sel[lc]
@@ -64,16 +72,21 @@ const getSelector = lc => sel[lc]
 const cat = { en: enCat, fr: frCat }
 const getCategories = (lc, ord) => cat[lc][ord ? 'ordinal' : 'cardinal']
 
+const range = { en: enRange, fr: frRange }
+const getRangeSelector = (lc) => range[lc]
+
 const PluralRules = getPluralRules(
   Intl.NumberFormat, // Not available in IE 10
   getSelector,
-  getCategories
+  getCategories,
+  getRangeSelector
 )
 export default PluralRules
 ```
 
-All arguments of `getPluralRules(NumberFormat, getSelector, getCategories)` are
-required.
+All arguments of
+`getPluralRules(NumberFormat, getSelector, getCategories, getRangeSelector)`
+are required.
 
 - `NumberFormat` should be `Intl.NumberFormat`, or a minimal implementation
   such as the one available at `intl-pluralrules/pseudo-number-format`. It
@@ -88,3 +101,6 @@ required.
   for the locale, either for cardinals (by default), or ordinals if `ord` is
   true. This function will be called only with values for which `getSelector`
   returns a function.
+- `getRangeSelector(lc)` should return a `function(start, end)` returning the
+  plural category of the range. `start` and `end` are the plural categories of
+  the corresponding values.

--- a/examples/src/factory.js
+++ b/examples/src/factory.js
@@ -5,6 +5,7 @@
 
 import { en, fr } from 'make-plural/cardinals'
 import { en as enCat, fr as frCat } from 'make-plural/pluralCategories'
+import { en as enRange, fr as frRange } from 'make-plural/ranges'
 import getPluralRules from '../../factory'
 
 const sel = { en, fr }
@@ -13,12 +14,19 @@ const getSelector = lc => sel[lc]
 const cat = { en: enCat, fr: frCat }
 const getCategories = (lc, ord) => cat[lc][ord ? 'ordinal' : 'cardinal']
 
+const range = { en: enRange, fr: frRange }
+const getRangeSelector = lc => range[lc]
+
 const PluralRules = getPluralRules(
   Intl.NumberFormat, // Not available in IE 10
   getSelector,
-  getCategories
+  getCategories,
+  getRangeSelector
 )
 
-const one = new PluralRules('en').select(1)
-const other = new PluralRules('en', { minimumSignificantDigits: 3 }).select(1)
-console.log('factory', { one, other })
+{
+  const one = new PluralRules('en').select(1)
+  const other = new PluralRules('en', { minimumSignificantDigits: 3 }).select(1)
+  const range = new PluralRules('en').selectRange(0, 1)
+  console.log('factory', { one, other, range })
+}

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
-node dist/factory.js | grep -q "factory { one: 'one', other: 'other' }" && echo "factory ok" || (echo "factory failed" && false)
+node dist/factory.js | grep -q "factory { one: 'one', other: 'other', range: 'other' }" && echo "factory ok" || (echo "factory failed" && false)
 node dist/ponyfill.js | grep -q "ponyfill { one: 'one', other: 'other' }" && echo "ponyfill ok" || (echo "ponyfill failed" && false)
 node dist/polyfill.js | grep -q "{ one: 'one', other: 'other' }" && echo "polyfill ok" || (echo "polyfill failed" && false)

--- a/src/factory.mjs
+++ b/src/factory.mjs
@@ -82,7 +82,8 @@ export default function getPluralRules(
         minimumFractionDigits,
         maximumFractionDigits,
         minimumSignificantDigits,
-        maximumSignificantDigits
+        maximumSignificantDigits,
+        roundingPriority
       } = this._nf.resolvedOptions()
       const opt = {
         locale: this._locale,
@@ -90,6 +91,7 @@ export default function getPluralRules(
         minimumFractionDigits,
         maximumFractionDigits,
         pluralCategories: getCategories(this._locale, this._type === 'ordinal'),
+        roundingPriority: roundingPriority || 'auto',
         type: this._type
       }
       if (typeof minimumSignificantDigits === 'number') {

--- a/src/factory.mjs
+++ b/src/factory.mjs
@@ -43,7 +43,8 @@ const getType = type => {
 export default function getPluralRules(
   NumberFormat,
   getSelector,
-  getCategories
+  getCategories,
+  getRangeSelector
 ) {
   const findLocale = locale => {
     do {
@@ -70,6 +71,7 @@ export default function getPluralRules(
     constructor(locales, opt = {}) {
       this._locale = resolveLocale(locales)
       this._select = getSelector(this._locale)
+      this._range = getRangeSelector(this._locale)
       this._type = getType(opt.type)
       this._nf = new NumberFormat('en', opt) // make-plural expects latin digits with . decimal separator
     }
@@ -104,6 +106,16 @@ export default function getPluralRules(
       if (!isFinite(number)) return 'other'
       const fmt = this._nf.format(Math.abs(number))
       return this._select(fmt, this._type === 'ordinal')
+    }
+
+    selectRange(start, end) {
+      if (!(this instanceof PluralRules))
+        throw new TypeError(`selectRange() called on incompatible ${this}`)
+      if (typeof start !== 'number') start = Number(start)
+      if (typeof end !== 'number') end = Number(end)
+      if (!isFinite(start) || !isFinite(end) || start > end)
+        throw new RangeError('start and end must be finite, with end >= start')
+      return this._range(this.select(start), this.select(end))
     }
   }
 

--- a/src/plural-rules.mjs
+++ b/src/plural-rules.mjs
@@ -1,5 +1,6 @@
 import * as P from 'make-plural/plurals'
 import * as C from 'make-plural/pluralCategories'
+import * as R from 'make-plural/ranges'
 import getPluralRules from './factory'
 import PseudoNumberFormat from './pseudo-number-format'
 
@@ -8,6 +9,7 @@ import PseudoNumberFormat from './pseudo-number-format'
 // cruft than for ES module exports.
 const Plurals = P.default || P
 const Categories = C.default || C
+const RangePlurals = R.default || R
 
 /* istanbul ignore next */
 const NumberFormat =
@@ -19,6 +21,12 @@ const id = lc => (lc === 'in' ? '_in' : lc === 'pt-PT' ? 'pt_PT' : lc)
 const getSelector = lc => Plurals[id(lc)]
 const getCategories = (lc, ord) =>
   Categories[id(lc)][ord ? 'ordinal' : 'cardinal']
+const getRangeSelector = lc => RangePlurals[id(lc)]
 
-const PluralRules = getPluralRules(NumberFormat, getSelector, getCategories)
+const PluralRules = getPluralRules(
+  NumberFormat,
+  getSelector,
+  getCategories,
+  getRangeSelector
+)
 export default PluralRules

--- a/src/plural-rules.test.mjs
+++ b/src/plural-rules.test.mjs
@@ -96,8 +96,10 @@ function suite(PluralRules) {
       const p = new PluralRules()
       expect(p.resolvedOptions).toBeInstanceOf(Function)
     })
+
     // https://crbug.com/v8/10832
-    test.skip('should return expected values', () => {
+    const test_ = process.version > 'v16' ? test : test.skip
+    test_('should return expected values', () => {
       const res = new PluralRules('fi-FI', {
         minimumIntegerDigits: 2,
         minimumSignificantDigits: 3
@@ -107,6 +109,7 @@ function suite(PluralRules) {
         minimumSignificantDigits: 3,
         maximumSignificantDigits: 21,
         pluralCategories: ['one', 'other'],
+        roundingPriority: 'auto',
         type: 'cardinal'
       })
       expect(res.locale).toMatch(/^fi\b/)

--- a/src/plural-rules.test.mjs
+++ b/src/plural-rules.test.mjs
@@ -2,6 +2,7 @@
 
 import * as Plurals from 'make-plural/plurals'
 import * as Categories from 'make-plural/pluralCategories'
+import * as RangePlurals from 'make-plural/ranges'
 import getPluralRules from './factory'
 import ActualPluralRules from './plural-rules'
 import PseudoNumberFormat from './pseudo-number-format'
@@ -178,6 +179,45 @@ function suite(PluralRules) {
       expect(p1.select(10)).toBe('many')
     })
   })
+
+  describe('#selectRange()', () => {
+    test('should return a string', () => {
+      const res = new PluralRules().selectRange(0, 1)
+      expect(res).toBe('other')
+    })
+    test('should complain if bound', () => {
+      const p = new PluralRules()
+      expect(p.selectRange.bind(null)).toThrow(TypeError)
+    })
+    test('should work for English', () => {
+      const p = new PluralRules('en')
+      expect(p.selectRange(0, 1)).toBe('other')
+      expect(p.selectRange('0.0', '1.0')).toBe('other')
+      expect(p.selectRange(1, 2)).toBe('other')
+    })
+    test('should work for French', () => {
+      const p = new PluralRules('fr')
+      expect(p.selectRange(0, 1)).toBe('one')
+      expect(p.selectRange('0.0', '1.0')).toBe('one')
+      expect(p.selectRange(1, 2)).toBe('other')
+    })
+    test('should work with minimumFractionDigits: 1', () => {
+      const p = new PluralRules('fr', { minimumFractionDigits: 1 })
+      expect(p.selectRange(0, 1)).toBe('one')
+      expect(p.selectRange('0.0', '1.0')).toBe('one')
+      expect(p.selectRange(1, 2)).toBe('other')
+    })
+    test('should work with maximumFractionDigits: 0', () => {
+      const p = new PluralRules('fr', { maximumFractionDigits: 0 })
+      expect(p.selectRange(0, 1)).toBe('one')
+      expect(p.selectRange('1.0', '1.1')).toBe('one')
+      expect(p.selectRange(1, 2)).toBe('other')
+    })
+    test('should complain if start > end', () => {
+      const p = new PluralRules('en')
+      expect(() => p.selectRange(2, 1)).toThrow(RangeError)
+    })
+  })
 }
 
 describe('With native Intl.NumberFormat', () => suite(ActualPluralRules))
@@ -187,10 +227,12 @@ describe('With PseudoNumberFormat', () => {
   const getSelector = lc => Plurals[id(lc)]
   const getCategories = (lc, ord) =>
     Categories[id(lc)][ord ? 'ordinal' : 'cardinal']
+  const getRangeSelector = lc => RangePlurals[id(lc)]
   const PluralRules = getPluralRules(
     PseudoNumberFormat,
     getSelector,
-    getCategories
+    getCategories,
+    getRangeSelector
   )
   suite(PluralRules)
 })

--- a/src/polyfill.mjs
+++ b/src/polyfill.mjs
@@ -9,7 +9,7 @@ if (typeof Intl === 'undefined') {
     this.Intl = { PluralRules }
   }
   PluralRules.polyfill = true
-} else if (!Intl.PluralRules) {
+} else if (!Intl.PluralRules || !Intl.PluralRules.prototype.selectRange) {
   Intl.PluralRules = PluralRules
   PluralRules.polyfill = true
 } else {


### PR DESCRIPTION
As specified here, currently at Stage 2: https://github.com/tc39/proposal-intl-numberformat-v3

Also includes `roundingPriority` support, if provided by the backing Intl.NumberFormat instance.

Due to the new `getRangeSelector` parameter of the factory, this will need to be released a breaking change. That also allows for continued use of `intl-pluralrules@1` for those who do not want or need `selectRange()`.