### PR TITLE
Behave more normally for locale resolution

### DIFF
--- a/src/factory.mjs
+++ b/src/factory.mjs
@@ -12,7 +12,6 @@ const canonicalizeLocaleList = locales => {
       const msg = `Locales should be strings, ${JSON.stringify(tag)} isn't.`
       throw new TypeError(msg)
     }
-    if (tag[0] === '*') continue
 
     const parts = tag.split('-')
 

--- a/src/factory.mjs
+++ b/src/factory.mjs
@@ -27,13 +27,6 @@ const canonicalizeLocaleList = locales => {
   return Object.keys(res)
 }
 
-const defaultLocale = () =>
-  /* istanbul ignore next */
-  (typeof navigator !== 'undefined' &&
-    navigator &&
-    (navigator.userLanguage || navigator.language)) ||
-  'en-US'
-
 const getType = type => {
   if (!type) return 'cardinal'
   if (type === 'cardinal' || type === 'ordinal') return type
@@ -60,7 +53,8 @@ export default function getPluralRules(
       const lc = findLocale(canonicalLocales[i])
       if (lc) return lc
     }
-    return findLocale(defaultLocale())
+    const lc = new NumberFormat().resolvedOptions().locale
+    return findLocale(lc)
   }
 
   class PluralRules {

--- a/src/factory.mjs
+++ b/src/factory.mjs
@@ -1,7 +1,3 @@
-// does not check for duplicate subtags
-const isStructurallyValidLanguageTag = locale =>
-  locale.split('-').every(subtag => /[a-z0-9]+/i.test(subtag))
-
 const canonicalizeLocaleList = locales => {
   if (!locales) return []
   if (!Array.isArray(locales)) locales = [locales]
@@ -17,12 +13,22 @@ const canonicalizeLocaleList = locales => {
       throw new TypeError(msg)
     }
     if (tag[0] === '*') continue
-    if (!isStructurallyValidLanguageTag(tag)) {
+
+    const parts = tag.split('-')
+
+    // does not check for duplicate subtags
+    if (!parts.every(subtag => /[a-z0-9]+/i.test(subtag))) {
       const strTag = JSON.stringify(tag)
       const msg = `The locale ${strTag} is not a structurally valid BCP 47 language tag.`
       throw new RangeError(msg)
     }
-    res[tag] = true
+
+    // always use lower case for primary language subtag
+    let lc = parts[0].toLowerCase()
+    // replace deprecated codes for Indonesian, Hebrew & Yiddish
+    parts[0] = { in: 'id', iw: 'he', ji: 'yi' }[lc] ?? lc
+
+    res[parts.join('-')] = true
   }
   return Object.keys(res)
 }

--- a/src/plural-rules.mjs
+++ b/src/plural-rules.mjs
@@ -16,7 +16,7 @@ const NumberFormat =
   (typeof Intl === 'object' && Intl.NumberFormat) || PseudoNumberFormat
 
 // make-plural exports are cast with safe-identifier to be valid JS identifiers
-const id = lc => (lc === 'in' ? '_in' : lc === 'pt-PT' ? 'pt_PT' : lc)
+const id = lc => (lc === 'pt-PT' ? 'pt_PT' : lc)
 
 const getSelector = lc => Plurals[id(lc)]
 const getCategories = (lc, ord) =>

--- a/src/plural-rules.test.mjs
+++ b/src/plural-rules.test.mjs
@@ -25,11 +25,6 @@ function suite(PluralRules) {
       const res = PluralRules.supportedLocalesOf(locales)
       expect(res).toMatchObject(locales)
     })
-    test('should ignore wildcards', () => {
-      const locales = ['en', '*', '*-foo', 'fi-FI']
-      const res = PluralRules.supportedLocalesOf(locales)
-      expect(res).toMatchObject(['en', 'fi-FI'])
-    })
     test('should accept String objects', () => {
       const res = PluralRules.supportedLocalesOf(new String('en'))
       expect(res).toMatchObject(['en'])
@@ -41,6 +36,7 @@ function suite(PluralRules) {
     test('should complain about bad tags', () => {
       expect(() => PluralRules.supportedLocalesOf('en-')).toThrow(RangeError)
       expect(() => PluralRules.supportedLocalesOf('-en')).toThrow(RangeError)
+      expect(() => PluralRules.supportedLocalesOf('*-en')).toThrow(RangeError)
     })
   })
 

--- a/src/plural-rules.test.mjs
+++ b/src/plural-rules.test.mjs
@@ -59,7 +59,7 @@ function suite(PluralRules) {
       expect(opt.locale.length).toBeGreaterThan(1)
     })
     test('should handle valid simple arguments correctly', () => {
-      const p = new PluralRules('pt-PT', { type: 'ordinal' })
+      const p = new PluralRules('PT-PT', { type: 'ordinal' })
       expect(p).toBeInstanceOf(Object)
       expect(p.select).toBeInstanceOf(Function)
       const opt = p.resolvedOptions()
@@ -67,7 +67,7 @@ function suite(PluralRules) {
       expect(opt.locale).toMatch(/^pt\b/)
     })
     test('should choose a locale correctly from multiple choices', () => {
-      const p = new PluralRules(['tlh', 'id', 'en'])
+      const p = new PluralRules(['tlh', 'IN', 'en'])
       expect(p).toBeInstanceOf(Object)
       expect(p.select).toBeInstanceOf(Function)
       const opt = p.resolvedOptions()
@@ -215,7 +215,7 @@ function suite(PluralRules) {
 describe('With native Intl.NumberFormat', () => suite(ActualPluralRules))
 
 describe('With PseudoNumberFormat', () => {
-  const id = lc => (lc === 'in' ? '_in' : lc === 'pt-PT' ? 'pt_PT' : lc)
+  const id = lc => (lc === 'pt-PT' ? 'pt_PT' : lc)
   const getSelector = lc => Plurals[id(lc)]
   const getCategories = (lc, ord) =>
     Categories[id(lc)][ord ? 'ordinal' : 'cardinal']

--- a/src/pseudo-number-format.mjs
+++ b/src/pseudo-number-format.mjs
@@ -1,13 +1,13 @@
 export default class PseudoNumberFormat {
   constructor(
-    lc, // locale is ignored; always use 'en'
+    lc, // locale is ignored; always use 'en-US' in format()
     {
       minimumIntegerDigits: minID,
       minimumFractionDigits: minFD,
       maximumFractionDigits: maxFD,
       minimumSignificantDigits: minSD,
       maximumSignificantDigits: maxSD
-    }
+    } = {}
   ) {
     this._minID = typeof minID === 'number' ? minID : 1
     this._minFD = typeof minFD === 'number' ? minFD : 0
@@ -28,6 +28,7 @@ export default class PseudoNumberFormat {
       opt.minimumSignificantDigits = this._minSD
       opt.maximumSignificantDigits = this._maxSD
     }
+    Object.defineProperty(opt, 'locale', { get: getDefaultLocale })
     return opt
   }
 
@@ -46,5 +47,18 @@ export default class PseudoNumberFormat {
     if (this._minFD > 0) return n.toFixed(this._minFD)
     if (this._maxFD === 0) return n.toFixed(0)
     return String(n)
+  }
+}
+
+function getDefaultLocale() {
+  if (
+    typeof Intl !== 'undefined' &&
+    typeof Intl.DateTimeFormat === 'function'
+  ) {
+    return new Intl.DateTimeFormat().resolvedOptions().locale
+  } else if (typeof navigator !== 'undefined') {
+    return navigator.userLanguage || navigator.language || 'en-US'
+  } else {
+    return 'en-US'
   }
 }


### PR DESCRIPTION
This is a set of fixes that improves the locale code handling to behave as expected:
- The primary language subtag no longer needs to be lower-cased to be recognised.
- Languages with updated codes use the modern one as their resolved value:
  - Indonesian: `in` → `id`
  - Hebrew: `iw`→ `he`
  - Yiddish: `ji`→`yi`
- No more invalid special-casing for using `'*'` as a locale code.
- To determine the default locale, look first at what other formatters (Intl.NumberFormat, Intl.DateTimeFormat) consider the default, until ultimately checking `navigator.language` or just falling back to `'en-US'`.