### PR TITLE
Drop IE 11 support

### DIFF
--- a/.github/workflows/browsers.yaml
+++ b/.github/workflows/browsers.yaml
@@ -16,6 +16,7 @@ jobs:
         with:
           username:  ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: intl-pluralrules
 
       - name: BrowserStackLocal Start
         uses: browserstack/github-actions/setup-local@master
@@ -23,13 +24,13 @@ jobs:
           local-testing: start
           local-identifier: random
 
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with: { node-version: 16.x }
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with: { node-version: 16 }
       - run: npm ci
       - run: python -m http.server 8000 &
 
-      - run: npm run test:ie11
+      - run: npm run test:browsers
 
       - name: BrowserStackLocal Stop
         uses: browserstack/github-actions/setup-local@master

--- a/.github/workflows/browsers.yaml
+++ b/.github/workflows/browsers.yaml
@@ -1,4 +1,4 @@
-name: IE11
+name: Browsers
 
 on:
   push:
@@ -14,7 +14,7 @@ jobs:
       - name: BrowserStack Env Setup
         uses: browserstack/github-actions/setup-env@master
         with:
-          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          username: ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           project-name: intl-pluralrules
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ including the `selectRange(start, end)` method introduced in [Intl.NumberFormat 
 Also useful if you need proper support for [`minimumFractionDigits`],
 which are only supported in Chrome 77 & later.
 
-For a polyfill without `selectRange()`, please use `intl-pluralrules@1`.
+For a polyfill without `selectRange()` and with IE 11 support, please use `intl-pluralrules@1`.
 
 [intl.pluralrules]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules
 [intl.numberformat v3]: https://github.com/tc39/proposal-intl-numberformat-v3/

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "chai": "^4.3.6",
         "make-plural": "^7.0.0",
         "mocha": "^10.0.0",
-        "mocha-selenium-bridge": "^0.2.3",
+        "mocha-selenium-bridge": "^0.3.0",
         "rollup": "^2.26.5",
         "rollup-plugin-terser": "^7.0.0",
         "test262-harness": "^10.0.0"
@@ -3361,20 +3361,61 @@
       }
     },
     "node_modules/mocha-selenium-bridge": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mocha-selenium-bridge/-/mocha-selenium-bridge-0.2.3.tgz",
-      "integrity": "sha512-QIo645MjxGy/iCyoLpkMglKZeC5CNtwDh4CVQD+QFzy7Wf9h4cnmLDfNSE55tXSZV2xcOojKpXIbMoqV2rI6cw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mocha-selenium-bridge/-/mocha-selenium-bridge-0.3.0.tgz",
+      "integrity": "sha512-9Ttea25rsM32sI/CuyuKE8ZEGSHHgdqqNgIt6T3X6agf5zFBnMp0/ngtJAd2l8ngz3WW3S1EtyUFAJAnMRO6mw==",
       "dev": true,
       "dependencies": {
         "selenium-webdriver": "^4.0.0-alpha.7",
-        "yaml": "^1.10.0",
-        "yargs": "^16.1.0"
+        "yaml": "^2.1.1",
+        "yargs": "^17.5.1"
       },
       "bin": {
         "mocha-selenium-bridge": "lib/cli.js"
       },
       "peerDependencies": {
         "mocha": ">=6"
+      }
+    },
+    "node_modules/mocha-selenium-bridge/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mocha-selenium-bridge/node_modules/yargs": {
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mocha-selenium-bridge/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
@@ -4760,12 +4801,12 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
       "dev": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -71,8 +71,9 @@
     "pretest262": "rollup -c test/rollup.test262.js",
     "test262": "test262-harness --error-for-failures --features-exclude cross-realm --prelude test/dist/test262-prelude.js 'test262/test/intl402/PluralRules/**/*.js'",
     "pretest:browsers": "npx rollup -c test/rollup.browser.js",
-    "test:browsers": "npm run test:edge && npm run test:safari",
+    "test:browsers": "npm run test:edge && npm run test:firefox && npm run test:safari",
     "test:edge": "BROWSER=Edge:110 mocha-selenium-bridge --driver ./test/browserstack-driver.js http://localhost:8000/test/browser-test.html",
+    "test:firefox": "BROWSER=Firefox:110 mocha-selenium-bridge --driver ./test/browserstack-driver.js http://localhost:8000/test/browser-test.html",
     "test:safari": "OS='OS X:Big Sur' BROWSER=Safari:14.1 mocha-selenium-bridge --driver ./test/browserstack-driver.js http://localhost:8000/test/browser-test.html"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "chai": "^4.3.6",
     "make-plural": "^7.0.0",
     "mocha": "^10.0.0",
-    "mocha-selenium-bridge": "^0.2.3",
+    "mocha-selenium-bridge": "^0.3.0",
     "rollup": "^2.26.5",
     "rollup-plugin-terser": "^7.0.0",
     "test262-harness": "^10.0.0"
@@ -70,7 +70,9 @@
     "test": "c8 mocha test/*.test.mjs",
     "pretest262": "rollup -c test/rollup.test262.js",
     "test262": "test262-harness --error-for-failures --features-exclude cross-realm --prelude test/dist/test262-prelude.js 'test262/test/intl402/PluralRules/**/*.js'",
-    "pretest:ie11": "npx rollup -c test/rollup.browser.js",
-    "test:ie11": "mocha-selenium-bridge --driver ./test/browserstack-driver.js http://localhost:8000/test/browser-test.html"
+    "pretest:browsers": "npx rollup -c test/rollup.browser.js",
+    "test:browsers": "npm run test:edge && npm run test:safari",
+    "test:edge": "BROWSER=Edge:110 mocha-selenium-bridge --driver ./test/browserstack-driver.js http://localhost:8000/test/browser-test.html",
+    "test:safari": "OS='OS X:Big Sur' BROWSER=Safari:14.1 mocha-selenium-bridge --driver ./test/browserstack-driver.js http://localhost:8000/test/browser-test.html"
   }
 }

--- a/test/browser-test.html
+++ b/test/browser-test.html
@@ -6,10 +6,8 @@
 
     <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/mocha-selenium-bridge/browser/reporter.js"></script>
-
-    <!-- Mocha v9 is last with IE 11 support: https://github.com/mochajs/mocha/discussions/4727 -->
-    <script src="https://unpkg.com/mocha@9.2.2/mocha.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/mocha@9.2.2/mocha.css" />
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
 
     <script src="./dist/browser-plural-rules.js"></script>
     <script src="./dist/browser-test-suite.js"></script>
@@ -17,8 +15,7 @@
   <body>
     <div id="mocha"></div>
     <script>
-      var isIE11 = !!window.MSInputMethodContext && !!document.documentMode
-      if (isIE11 || navigator.webdriver) mocha.reporter(Bridge)
+      if (navigator.webdriver) mocha.reporter(Bridge)
       mocha.setup('bdd')
       prTests.suite(PluralRules)
       mocha.run()

--- a/test/browserstack-driver.js
+++ b/test/browserstack-driver.js
@@ -6,14 +6,13 @@ const localIdentifier = process.env.BROWSERSTACK_LOCAL_IDENTIFIER
 
 const server = `http://${username}:${accessKey}@hub.browserstack.com/wd/hub`
 
+const [os, osVersion] = (process.env.OS ?? 'Windows:10').split(':')
+const [browserName, browserVersion] = process.env.BROWSER.split(':')
+
 const capabilities = {
-  'bstack:options': {
-    local: 'true',
-    os: 'Windows',
-    osVersion: '10'
-  },
-  browserName: 'IE',
-  browserVersion: '11.0'
+  'bstack:options': { local: 'true', os, osVersion },
+  browserName,
+  browserVersion
 }
 
 if (localIdentifier)

--- a/test/rollup.test262.js
+++ b/test/rollup.test262.js
@@ -4,8 +4,7 @@ import commonjs from '@rollup/plugin-commonjs'
 
 /**
  * For backwards compatibility and utility as a polyfill,
- * intl-pluralrules is transpiled to work in old browsers
- * which do not support e.g. classes, such as IE 11.
+ * intl-pluralrules is transpiled to work in older browsers.
  *
  * For test262 we should not check the validity of that transpilation,
  * so the current environment is used as a target instead.


### PR DESCRIPTION
IE 11 has reached its end-of-life last year, and it's e.g. considered `dead` by Browserslist.

This drops the currently-failing CI tests for IE 11 support, and uses Edge 110 & Safari 14.1 as a new baseline instead.